### PR TITLE
Remove Navbar component import from index.astro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,6 @@ import Layout from "@layouts/Layout.astro";
 import SectionTitle from "@ui/SectionTitle.astro";
 import SectionContainer from "@ui/SectionContainer.astro";
 import Home from "@components/Home.astro";
-import Navbar from "../components/Navbar.astro";
 import Skills from "@components/Skills.astro";
 import Contact from "@components/Contact.astro";
 import ProjectCard from "@components/FeaturedProjects.astro";
@@ -17,7 +16,6 @@ import UserIcon from "@components/icons/UserIcon.astro";
 
 <Layout>
   <!-- <Navbar /> -->
-  <Navbar />
 
   <!-- Section Home -->
   <SectionContainer id="home" class="py-16 md:py-28">


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed unused `Navbar` component import from `index.astro`.

- Commented out the `Navbar` component usage in the layout.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.astro</strong><dd><code>Removed unused Navbar component import and usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/index.astro

<li>Removed the import statement for <code>Navbar</code>.<br> <li> Commented out the <code>Navbar</code> component usage in the layout.


</details>


  </td>
  <td><a href="https://github.com/suarez0999/portafolio/pull/9/files#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>